### PR TITLE
Add SharePoint Excel form demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# LIMS1
-First test of the LIMS system with codex
+# SharePoint Excel Form Demo
+
+This project demonstrates loading an Excel table from SharePoint and generating a dynamic form based on the table schema. It is read-only and contains no data modification features.
+
+## Quick start
+
+```bash
+# serve the static files
+npx serve .
+```
+
+Open the served URL in a browser.
+
+## Configuration
+
+Edit `config.json` to point to your SharePoint file:
+
+- `sharepointSite`: SharePoint site identifier.
+- `filePath`: Path to the Excel file within the site.
+- `worksheet` (optional): Worksheet name containing the table.
+- `table`: Named table to read.
+- `locale`: Locale string (e.g., `de-DE`).
+
+Authentication is assumed to be handled externally.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+  "sharepointSite": "{site-id}",
+  "filePath": "/Shared%20Documents/sample.xlsx",
+  "worksheet": "Tabelle1",
+  "table": "MyTable",
+  "locale": "de-DE"
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <title>Dynamisches Formular aus Excel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="app">
+    <div id="error" class="hidden"></div>
+    <div id="form-container"></div>
+    <div id="preview"></div>
+  </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+  <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lims1",
+  "version": "1.0.0",
+  "description": "SharePoint Excel form demo",
+  "main": "index.js",
+  "scripts": {
+    "test": "node -e \"console.log('no tests')\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/formGenerator.js
+++ b/src/formGenerator.js
@@ -1,0 +1,97 @@
+// Functions to infer form schema and render the form
+
+function detectType(name, sampleValues, validation) {
+  const lower = name.toLowerCase();
+  const required = /\*|\[required\]/i.test(name);
+  let type = 'text';
+  const info = [];
+
+  const hasValidationList = validation && validation.rule && validation.rule.inCellDropDown;
+  if (hasValidationList) {
+    type = 'select';
+    info.push('Liste aus Datenvalidierung');
+  } else if (/notiz|beschreibung|kommentar/i.test(lower)) {
+    type = 'textarea';
+  } else if (/foto|bild|image|attachment|datei/i.test(lower)) {
+    type = 'file';
+  } else {
+    const values = sampleValues.filter(v => v !== null && v !== undefined);
+    const allNumbers = values.every(v => !isNaN(v));
+    const allInts = allNumbers && values.every(v => Number.isInteger(Number(v)));
+    const allDates = values.every(v => /\d{2}\.\d{2}\.\d{4}/.test(v));
+    const allBools = values.every(v => /^(ja|nein|true|false|bool|check)$/i.test(String(v)));
+
+    if (allDates || /datum/i.test(lower)) {
+      type = 'date';
+    } else if (allBools) {
+      type = 'checkbox';
+    } else if (allNumbers) {
+      type = 'number';
+      if (!allInts) info.push('dezimal');
+    }
+  }
+
+  return { name, type, required, validation, info };
+}
+
+export function inferSchema(table) {
+  const schema = table.columns.map((col, idx) => {
+    const sampleValues = table.rows.map(r => r[idx]);
+    return detectType(col.name, sampleValues, col.validation);
+  });
+  return schema;
+}
+
+export function generateForm(schema, container) {
+  const form = document.createElement('form');
+  schema.forEach(field => {
+    const wrapper = document.createElement('div');
+    const label = document.createElement('label');
+    label.textContent = field.name;
+    let input;
+    switch (field.type) {
+      case 'date':
+        input = document.createElement('input');
+        input.type = 'date';
+        input.placeholder = 'dd.MM.yyyy';
+        break;
+      case 'number':
+        input = document.createElement('input');
+        input.type = 'number';
+        if (field.info.includes('dezimal')) input.step = '0.01';
+        break;
+      case 'checkbox':
+        input = document.createElement('input');
+        input.type = 'checkbox';
+        break;
+      case 'select':
+        input = document.createElement('select');
+        const opts = field.validation && field.validation.formula1;
+        if (opts) {
+          opts.replace(/[=\"]?/g, '').split(',').forEach(o => {
+            const option = document.createElement('option');
+            option.value = o.trim();
+            option.textContent = o.trim();
+            input.appendChild(option);
+          });
+        }
+        break;
+      case 'textarea':
+        input = document.createElement('textarea');
+        break;
+      case 'file':
+        input = document.createElement('input');
+        input.type = 'file';
+        input.multiple = true;
+        break;
+      default:
+        input = document.createElement('input');
+        input.type = 'text';
+    }
+    if (field.required) input.required = true;
+    wrapper.appendChild(label);
+    wrapper.appendChild(input);
+    form.appendChild(wrapper);
+  });
+  container.appendChild(form);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,44 @@
+import { fetchTable } from './sharepointClient.js';
+import { generateForm, inferSchema } from './formGenerator.js';
+
+async function init() {
+  const errorBanner = document.getElementById('error');
+  const formContainer = document.getElementById('form-container');
+  const preview = document.getElementById('preview');
+
+  async function load() {
+    errorBanner.classList.add('hidden');
+    formContainer.innerHTML = '';
+    preview.innerHTML = '';
+    try {
+      const configResp = await fetch('../config.json');
+      const config = await configResp.json();
+      const table = await fetchTable(config);
+      const schema = inferSchema(table);
+      generateForm(schema, formContainer);
+      renderPreview(schema, preview);
+    } catch (err) {
+      showError(err);
+    }
+  }
+
+  function showError(err) {
+    errorBanner.textContent = `Fehler beim Laden: ${err.message}`;
+    const btn = document.createElement('button');
+    btn.textContent = 'Erneut versuchen';
+    btn.onclick = load;
+    errorBanner.appendChild(document.createElement('br'));
+    errorBanner.appendChild(btn);
+    errorBanner.classList.remove('hidden');
+  }
+
+  function renderPreview(schema, el) {
+    const pre = document.createElement('pre');
+    pre.textContent = JSON.stringify(schema, null, 2);
+    el.appendChild(pre);
+  }
+
+  await load();
+}
+
+init();

--- a/src/sharepointClient.js
+++ b/src/sharepointClient.js
@@ -1,0 +1,35 @@
+// Thin client for SharePoint Excel access.
+// Assumes authentication is already handled elsewhere.
+// Uses Microsoft Graph table endpoints to fetch schema and sample rows.
+
+export async function fetchTable(config) {
+  const { sharepointSite, filePath, worksheet, table } = config;
+  const base = `https://graph.microsoft.com/v1.0/sites/${sharepointSite}/drive/root:${filePath}:/workbook`;
+  const ws = worksheet ? `/worksheets/${worksheet}` : '';
+  const tablePath = `${base}${ws}/tables/${table}`;
+
+  const [columnsResp, rowsResp] = await Promise.all([
+    fetch(`${tablePath}/columns?$expand=dataValidation`),
+    fetch(`${tablePath}/rows?$top=5`)
+  ]);
+
+  if (!columnsResp.ok) {
+    throw new Error(`Spalten konnten nicht geladen werden (${columnsResp.status})`);
+  }
+  if (!rowsResp.ok) {
+    throw new Error(`Zeilen konnten nicht geladen werden (${rowsResp.status})`);
+  }
+
+  const columnsJson = await columnsResp.json();
+  const rowsJson = await rowsResp.json();
+
+  const columns = columnsJson.value.map(col => ({
+    name: col.name,
+    address: col.address,
+    validation: col.dataValidation,
+  }));
+
+  const rows = rowsJson.value.map(r => r.values[0]);
+
+  return { columns, rows };
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,25 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+.hidden {
+  display: none;
+}
+#error {
+  background-color: #f8d7da;
+  color: #721c24;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+form div {
+  margin-bottom: 10px;
+}
+label {
+  display: block;
+  margin-bottom: 4px;
+}
+#preview {
+  margin-top: 20px;
+  border-top: 1px solid #ccc;
+  padding-top: 10px;
+}


### PR DESCRIPTION
## Summary
- build static web demo that fetches an Excel named table from SharePoint and renders a localized form with a preview panel
- add thin SharePoint client and schema inference logic for field types and requirements
- document configuration and quick start; remove placeholder demo GIF

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad638c3f30832480fb99a60e64c70a