### PR TITLE
Allow custom spreadsheet path with on-page status logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # INFOTable Viewer
 
-Simple static page that reads an Excel workbook and displays the sheet named `INFOTable` as an HTML table.
+Simple static page that reads the workbook `TestData.xlsx` and displays the table named `INFOTable` as an HTML table.
 
-Place `INFOTable.xlsx` in the project root and serve the folder using any static file server:
+Place `TestData.xlsx` in the project root (for example, the OneDrive folder `C:\Users\gimenezherrerosergj\OneDrive - ApplusGlobal\CODEX\Applus Laboratories. IMA & Barcelona - PowerApps LIMS`) and serve the folder using any static file server:
 
 ```bash
 npx serve .
 ```
 
-Open the served URL and the table contents will be rendered in the browser.
+Open the served URL, adjust the **Excel file path** field if necessary, and click **Load** to render the table.
+
+If loading fails, check the debug log under the table for step-by-step status messages showing each fetch and parse stage.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,12 @@
 </head>
 <body>
   <h1>INFOTable contents</h1>
+  <label for="file">Excel file path:</label>
+  <input id="file" type="text" value="TestData.xlsx" />
+  <button id="loadBtn">Load</button>
   <div id="table">Loading...</div>
+  <h2>Debug log</h2>
+  <pre id="debug"></pre>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="viewer.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- let users specify the Excel file path and reload via a Load button
- log fetch status and parsing steps to on-page debug area
- document usage and include example OneDrive path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aed0b2f880832497d5604f06957b0c