### PR TITLE
Select local Excel file for InfoTable display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # INFOTable Viewer
 
-Simple static page that reads an Excel workbook and displays the sheet named `INFOTable` as an HTML table.
+Simple static page that reads the workbook `TestData.xls` and displays the table named `InfoTable` as an HTML table.
 
-Place `INFOTable.xlsx` in the project root and serve the folder using any static file server:
+Serve the folder using any static file server:
 
 ```bash
 npx serve .
 ```
 
-Open the served URL and the table contents will be rendered in the browser.
+Open the served URL, click **Choose File**, and select `TestData.xls` from the folder `C:\Hutchinson old`. Then click **Load** to render the table.
+
+If loading fails, check the debug log under the table for step-by-step status messages showing each read and parse stage.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,12 @@
 </head>
 <body>
   <h1>INFOTable contents</h1>
-  <div id="table">Loading...</div>
+  <label for="fileInput">Excel file:</label>
+  <input id="fileInput" type="file" accept=".xls,.xlsx" />
+  <button id="loadBtn">Load</button>
+  <div id="table">No file loaded</div>
+  <h2>Debug log</h2>
+  <pre id="debug"></pre>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="viewer.js"></script>
 </body>

--- a/viewer.js
+++ b/viewer.js
@@ -1,15 +1,32 @@
-async function loadTable() {
+async function loadTable(file) {
+  const debug = msg => {
+    console.log(msg);
+    const el = document.getElementById('debug');
+    if (el) el.textContent += msg + '\n';
+  };
   try {
-    const resp = await fetch('INFOTable.xlsx');
-    if (!resp.ok) throw new Error('unable to fetch INFOTable.xlsx');
-    const buf = await resp.arrayBuffer();
+    debug('Reading ' + file.name + '...');
+    const buf = await file.arrayBuffer();
+    debug('Workbook loaded, parsing...');
     const wb = XLSX.read(buf, { type: 'array' });
-    const sheetName = 'INFOTable';
-    let ws = wb.Sheets[sheetName];
-    if (!ws) throw new Error('sheet "INFOTable" not found');
-    const rows = XLSX.utils.sheet_to_json(ws, { header: 1 });
+    debug('Workbook sheets: ' + wb.SheetNames.join(', '));
+
+    const name = wb.Workbook?.Names
+      ? wb.Workbook.Names.find(n => n.Name.toLowerCase() === 'infotable')
+      : null;
+    if (!name) throw new Error('table "InfoTable" not found');
+    debug('Found table range: ' + name.Ref);
+
+    const [sheetNameRaw, range] = name.Ref.split('!');
+    const sheetName = sheetNameRaw.replace(/^'/, '').replace(/'$/, '');
+    debug(`Using sheet "${sheetName}" range "${range}"`);
+    const ws = wb.Sheets[sheetName];
+    if (!ws) throw new Error(`sheet "${sheetName}" not found`);
+    const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range });
+    debug('Rendering ' + rows.length + ' rows');
     render(rows);
   } catch (err) {
+    debug('Error: ' + err.message);
     document.getElementById('table').textContent = 'Error: ' + err.message;
   }
 }
@@ -30,4 +47,17 @@ function render(rows) {
   container.appendChild(table);
 }
 
-loadTable();
+document.getElementById('loadBtn').addEventListener('click', () => {
+  const input = document.getElementById('fileInput');
+  const file = input.files[0];
+  document.getElementById('debug').textContent = '';
+  if (!file) {
+    const msg = 'No file selected';
+    console.log(msg);
+    document.getElementById('debug').textContent = msg;
+    document.getElementById('table').textContent = msg;
+    return;
+  }
+  document.getElementById('table').textContent = 'Loading...';
+  loadTable(file);
+});


### PR DESCRIPTION
## Summary
- read `InfoTable` from a user-chosen Excel file using FileReader
- let users pick the workbook via a file input instead of a text path
- document selecting `TestData.xls` from `C:\Hutchinson old` and using the debug log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aed0b2f880832497d5604f06957b0c