### PR TITLE
Add status display for INFOTable viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
 <body>
   <h1>INFOTable contents</h1>
   <div id="table">Loading...</div>
+  <h2>Status</h2>
+  <div id="status">Loading status...</div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="viewer.js"></script>
 </body>

--- a/viewer.js
+++ b/viewer.js
@@ -21,6 +21,18 @@ async function loadTable() {
   }
 }
 
+async function loadStatus() {
+  try {
+    // Adjust the path below to point to the status file in OneDrive
+    const resp = await fetch('status.txt');
+    if (!resp.ok) throw new Error('unable to fetch status.txt');
+    const text = await resp.text();
+    document.getElementById('status').textContent = text;
+  } catch (err) {
+    document.getElementById('status').textContent = 'Error: ' + err.message;
+  }
+}
+
 function render(rows) {
   const container = document.getElementById('table');
   container.innerHTML = '';
@@ -38,3 +50,4 @@ function render(rows) {
 }
 
 loadTable();
+loadStatus();


### PR DESCRIPTION
## Summary
- show status from a status.txt file in the page
- fetch status.txt in viewer.js and render to a new status section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aedc6083a48324b8aacb67039d4f59