### PR TITLE
Load fixed TestData workbook and show C1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # INFOTable Viewer
 
-Simple static page that reads an Excel workbook and displays the sheet named `INFOTable` as an HTML table.
+Simple static page that reads the workbook `TestData.xlsm` and displays the table named `INFOTable` as an HTML table.
 
-Place `INFOTable.xlsx` in the project root and serve the folder using any static file server:
+Serve the folder using any static file server:
 
 ```bash
 npx serve .
 ```
 
-Open the served URL and the table contents will be rendered in the browser.
+Open the served URL and click **Load workbook**. The page fetches `TestData.xlsm` from the same directory, shows the value of cell `C1`, and then renders the `INFOTable` range.
+
+If loading fails, check the debug log under the table for step-by-step status messages showing each read and parse stage.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,13 @@
 </head>
 <body>
   <h1>INFOTable contents</h1>
-  <div id="table">Loading...</div>
+  <button id="loadBtn">Load workbook</button>
+  <h2>Cell C1</h2>
+  <div id="cell">No file loaded</div>
+  <h2>INFOTable</h2>
+  <div id="table">No file loaded</div>
+  <h2>Debug log</h2>
+  <pre id="debug"></pre>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="viewer.js"></script>
 </body>

--- a/viewer.js
+++ b/viewer.js
@@ -1,15 +1,44 @@
+// Workbook expected alongside index.html, e.g., copied from
+// C:\\Hutchinson old\\TestData.xlsm
+const FILE_PATH = 'TestData.xlsm';
+
 async function loadTable() {
+  const debug = msg => {
+    console.log(msg);
+    const el = document.getElementById('debug');
+    if (el) el.textContent += msg + '\n';
+  };
   try {
-    const resp = await fetch('INFOTable.xlsx');
-    if (!resp.ok) throw new Error('unable to fetch INFOTable.xlsx');
+    debug('Fetching ' + FILE_PATH + '...');
+    const resp = await fetch(FILE_PATH);
+    if (!resp.ok) throw new Error('unable to fetch ' + FILE_PATH);
     const buf = await resp.arrayBuffer();
+    debug('Workbook loaded, parsing...');
     const wb = XLSX.read(buf, { type: 'array' });
-    const sheetName = 'INFOTable';
-    let ws = wb.Sheets[sheetName];
-    if (!ws) throw new Error('sheet "INFOTable" not found');
-    const rows = XLSX.utils.sheet_to_json(ws, { header: 1 });
+    debug('Workbook sheets: ' + wb.SheetNames.join(', '));
+
+    const name = wb.Workbook?.Names
+      ? wb.Workbook.Names.find(n => n.Name.toLowerCase() === 'infotable')
+      : null;
+    if (!name) throw new Error('table "INFOTable" not found');
+    debug('Found table range: ' + name.Ref);
+
+    const [sheetNameRaw, range] = name.Ref.split('!');
+    const sheetName = sheetNameRaw.replace(/^'/, '').replace(/'$/, '');
+    debug(`Using sheet "${sheetName}" range "${range}"`);
+    const ws = wb.Sheets[sheetName];
+    if (!ws) throw new Error(`sheet "${sheetName}" not found`);
+
+    const c1 = ws['C1'] ? ws['C1'].v : '';
+    debug('Cell C1 value: ' + c1);
+    document.getElementById('cell').textContent = c1;
+
+    const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range });
+    debug('Rendering ' + rows.length + ' rows');
     render(rows);
   } catch (err) {
+    debug('Error: ' + err.message);
+    document.getElementById('cell').textContent = 'Error';
     document.getElementById('table').textContent = 'Error: ' + err.message;
   }
 }
@@ -30,4 +59,9 @@ function render(rows) {
   container.appendChild(table);
 }
 
-loadTable();
+document.getElementById('loadBtn').addEventListener('click', () => {
+  document.getElementById('debug').textContent = '';
+  document.getElementById('cell').textContent = 'Loading...';
+  document.getElementById('table').textContent = 'Loading...';
+  loadTable();
+});


### PR DESCRIPTION
## Summary
- add Load button that fetches `TestData.xlsm` and displays cell C1 before the table
- parse and render `INFOTable` from the workbook with debug logging
- document the fixed file path and new workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aed0b2f880832497d5604f06957b0c