### PR TITLE
Clean viewer fetch logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,12 @@
 # INFOTable Viewer
 
-
-Simple static page that reads the workbook `TestData.xls` and displays the table named `InfoTable` as an HTML table.
-
-Serve the folder using any static file server:
 Simple static page that reads the workbook `TestData.xlsx` and displays the table named `INFOTable` as an HTML table.
 
-Place `TestData.xlsx` in the project root (for example, the OneDrive folder `C:\Users\gimenezherrerosergj\OneDrive - ApplusGlobal\CODEX\Applus Laboratories. IMA & Barcelona - PowerApps LIMS`) and serve the folder using any static file server:
-
+Place `TestData.xlsx` in the project root (for example, the OneDrive folder `C:\\Users\\gimenezherrerosergj\\OneDrive - ApplusGlobal\\CODEX\\Applus Laboratories. IMA & Barcelona - PowerApps LIMS`) and serve the folder using any static file server:
 
 ```bash
 npx serve .
 ```
-
-
 
 Open the served URL, adjust the **Excel file path** field if necessary, and click **Load** to render the table.
 

--- a/viewer.js
+++ b/viewer.js
@@ -1,4 +1,3 @@
-
 async function loadTable(file) {
   const debug = msg => {
     console.log(msg);
@@ -6,22 +5,15 @@ async function loadTable(file) {
     if (el) el.textContent += msg + '\n';
   };
   try {
-
-    debug('Reading ' + file.name + '...');
-    const buf = await file.arrayBuffer();
-
     debug('Fetching ' + file + '...');
     const resp = await fetch(file);
     debug(`Fetch status: ${resp.status}`);
     if (!resp.ok) throw new Error('unable to fetch ' + file);
-    const resp = await fetch('TestData.xlsx');
-    if (!resp.ok) throw new Error('unable to fetch TestData.xlsx');
 
     const buf = await resp.arrayBuffer();
     debug('Workbook loaded, parsing...');
     const wb = XLSX.read(buf, { type: 'array' });
     debug('Workbook sheets: ' + wb.SheetNames.join(', '));
-
 
     const name = wb.Workbook && wb.Workbook.Names
       ? wb.Workbook.Names.find(n => n.Name === 'INFOTable')
@@ -37,13 +29,6 @@ async function loadTable(file) {
 
     const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range });
     debug('Rendering ' + rows.length + ' rows');
-
-
-    const [sheetNameRaw, range] = name.Ref.split('!');
-    const sheetName = sheetNameRaw.replace(/^'/, '').replace(/'$/, '');
-    const ws = wb.Sheets[sheetName];
-    if (!ws) throw new Error(`sheet "${sheetName}" not found`);
-    const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range });
     render(rows);
   } catch (err) {
     debug('Error: ' + err.message);
@@ -68,21 +53,6 @@ function render(rows) {
 }
 
 document.getElementById('loadBtn').addEventListener('click', () => {
-
-  const input = document.getElementById('fileInput');
-  const file = input.files[0];
-  document.getElementById('debug').textContent = '';
-  if (!file) {
-    const msg = 'No file selected';
-    console.log(msg);
-    document.getElementById('debug').textContent = msg;
-    document.getElementById('table').textContent = msg;
-    return;
-  }
-  document.getElementById('table').textContent = 'Loading...';
-  loadTable(file);
-});
-
   const file = document.getElementById('file').value.trim();
   document.getElementById('table').textContent = 'Loading...';
   document.getElementById('debug').textContent = '';


### PR DESCRIPTION
## Summary
- remove merge remnants in viewer.js
- consolidate Excel fetch and table rendering
- trim duplicated README text about serving TestData.xlsx

## Testing
- `node --check viewer.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aefcbe13ec83248962206ad0bca86f