### PR TITLE
Remove bundled workbook and require explicit file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,10 @@
 # INFOTable Viewer
-
-
-Simple static page that reads the workbook `TestData.xls` and displays the table named `InfoTable` as an HTML table.
+Simple static page that reads a workbook and displays the table named `INFOTable` as an HTML table.
 
 Serve the folder using any static file server:
-Simple static page that reads the workbook `TestData.xlsx` and displays the table named `INFOTable` as an HTML table.
-
-Place `TestData.xlsx` in the project root (for example, the OneDrive folder `C:\Users\gimenezherrerosergj\OneDrive - ApplusGlobal\CODEX\Applus Laboratories. IMA & Barcelona - PowerApps LIMS`) and serve the folder using any static file server:
-
 
 ```bash
 npx serve .
 ```
 
-
-
-Open the served URL, adjust the **Excel file path** field if necessary, and click **Load** to render the table.
-
-If loading fails, check the debug log under the table for step-by-step status messages showing each fetch and parse stage.
+Open the served URL, enter the path to your workbook in the **Excel file path** field, and click **Load** to render the table. If loading fails, check the debug log under the table for step-by-step status messages showing each fetch and parse stage.

--- a/index.html
+++ b/index.html
@@ -8,11 +8,10 @@
 <body>
   <h1>INFOTable contents</h1>
 
-
   <label for="file">Excel file path:</label>
-  <input id="file" type="text" value="TestData.xlsx" />
+  <input id="file" type="text" placeholder="path/to/workbook.xlsx" />
   <button id="loadBtn">Load</button>
-  <div id="table">Loading...</div>
+  <div id="table"></div>
   <h2>Debug log</h2>
   <pre id="debug"></pre>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>

--- a/viewer.js
+++ b/viewer.js
@@ -1,4 +1,3 @@
-
 async function loadTable(file) {
   const debug = msg => {
     console.log(msg);
@@ -6,22 +5,15 @@ async function loadTable(file) {
     if (el) el.textContent += msg + '\n';
   };
   try {
-
-    debug('Reading ' + file.name + '...');
-    const buf = await file.arrayBuffer();
-
     debug('Fetching ' + file + '...');
     const resp = await fetch(file);
     debug(`Fetch status: ${resp.status}`);
     if (!resp.ok) throw new Error('unable to fetch ' + file);
-    const resp = await fetch('TestData.xlsx');
-    if (!resp.ok) throw new Error('unable to fetch TestData.xlsx');
 
     const buf = await resp.arrayBuffer();
     debug('Workbook loaded, parsing...');
     const wb = XLSX.read(buf, { type: 'array' });
     debug('Workbook sheets: ' + wb.SheetNames.join(', '));
-
 
     const name = wb.Workbook && wb.Workbook.Names
       ? wb.Workbook.Names.find(n => n.Name === 'INFOTable')
@@ -37,13 +29,6 @@ async function loadTable(file) {
 
     const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range });
     debug('Rendering ' + rows.length + ' rows');
-
-
-    const [sheetNameRaw, range] = name.Ref.split('!');
-    const sheetName = sheetNameRaw.replace(/^'/, '').replace(/'$/, '');
-    const ws = wb.Sheets[sheetName];
-    if (!ws) throw new Error(`sheet "${sheetName}" not found`);
-    const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range });
     render(rows);
   } catch (err) {
     debug('Error: ' + err.message);
@@ -68,25 +53,9 @@ function render(rows) {
 }
 
 document.getElementById('loadBtn').addEventListener('click', () => {
-
-  const input = document.getElementById('fileInput');
-  const file = input.files[0];
-  document.getElementById('debug').textContent = '';
-  if (!file) {
-    const msg = 'No file selected';
-    console.log(msg);
-    document.getElementById('debug').textContent = msg;
-    document.getElementById('table').textContent = msg;
-    return;
-  }
-  document.getElementById('table').textContent = 'Loading...';
-  loadTable(file);
-});
-
   const file = document.getElementById('file').value.trim();
   document.getElementById('table').textContent = 'Loading...';
   document.getElementById('debug').textContent = '';
   loadTable(file);
 });
 
-loadTable(document.getElementById('file').value);


### PR DESCRIPTION
## Summary
- drop TestData.xlsx sample workbook
- require users to specify the Excel path in the viewer
- streamline docs to match explicit-file workflow

## Testing
- `node --check viewer.js && echo "syntax ok"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aefcbe13ec83248962206ad0bca86f