### PR TITLE
Add diagnostic Excel loader with robust logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,14 +6,31 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>INFOTable contents</h1>
+  <h1>INFOTable Viewer</h1>
 
-  <label for="file">Excel file path:</label>
-  <input id="file" type="text" placeholder="path/to/workbook.xlsx" />
-  <button id="loadBtn">Load</button>
+  <div>
+    <label for="urlInput">Excel URL:</label>
+    <input id="urlInput" type="text" placeholder="http://localhost:5000/TestData.xlsm" />
+    <button id="loadUrlBtn">Load via URL</button>
+  </div>
+
+  <div>
+    <label for="fileInput">Local file:</label>
+    <input id="fileInput" type="file" accept=".xlsx,.xlsm,.xlsb,.xls" />
+    <button id="loadFileBtn">Load local file</button>
+  </div>
+
+  <div id="status"></div>
+
+  <h2>C1 Cell</h2>
+  <div id="cellC1"></div>
+
+  <h2>INFOTable</h2>
   <div id="table"></div>
+
   <h2>Debug log</h2>
   <pre id="debug"></pre>
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="viewer.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -10,3 +10,11 @@ td, th {
   border: 1px solid #ccc;
   padding: 4px 8px;
 }
+
+#debug {
+  border: 1px solid #ccc;
+  padding: 4px;
+  height: 200px;
+  overflow: auto;
+  background: #f9f9f9;
+}

--- a/viewer.js
+++ b/viewer.js
@@ -1,42 +1,22 @@
-async function loadTable(file) {
-  const debug = msg => {
-    console.log(msg);
-    const el = document.getElementById('debug');
-    if (el) el.textContent += msg + '\n';
-  };
-  try {
-    debug('Fetching ' + file + '...');
-    const resp = await fetch(file);
-    debug(`Fetch status: ${resp.status}`);
-    if (!resp.ok) throw new Error('unable to fetch ' + file);
+/* global XLSX */
 
-    const buf = await resp.arrayBuffer();
-    debug('Workbook loaded, parsing...');
-    const wb = XLSX.read(buf, { type: 'array' });
-    debug('Workbook sheets: ' + wb.SheetNames.join(', '));
-
-    const name = wb.Workbook && wb.Workbook.Names
-      ? wb.Workbook.Names.find(n => n.Name === 'INFOTable')
-      : null;
-    if (!name) throw new Error('table "INFOTable" not found');
-    debug('Found table range: ' + name.Ref);
-
-    const [sheetNameRaw, range] = name.Ref.split('!');
-    const sheetName = sheetNameRaw.replace(/^'/, '').replace(/'$/, '');
-    debug(`Using sheet "${sheetName}" range "${range}"`);
-    const ws = wb.Sheets[sheetName];
-    if (!ws) throw new Error(`sheet "${sheetName}" not found`);
-
-    const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range });
-    debug('Rendering ' + rows.length + ' rows');
-    render(rows);
-  } catch (err) {
-    debug('Error: ' + err.message);
-    document.getElementById('table').textContent = 'Error: ' + err.message;
-  }
+function log(msg) {
+  console.log(msg);
+  const el = document.getElementById('debug');
+  if (el) el.textContent += msg + '\n';
 }
 
-function render(rows) {
+function clearLog() {
+  const el = document.getElementById('debug');
+  if (el) el.textContent = '';
+}
+
+function setStatus(msg) {
+  const el = document.getElementById('status');
+  if (el) el.textContent = msg || '';
+}
+
+function renderTable(rows) {
   const container = document.getElementById('table');
   container.innerHTML = '';
   const table = document.createElement('table');
@@ -52,10 +32,142 @@ function render(rows) {
   container.appendChild(table);
 }
 
-document.getElementById('loadBtn').addEventListener('click', () => {
-  const file = document.getElementById('file').value.trim();
-  document.getElementById('table').textContent = 'Loading...';
-  document.getElementById('debug').textContent = '';
-  loadTable(file);
-});
+function handleWorkbook(ab) {
+  try {
+    log('Parsing workbook...');
+    const wb = XLSX.read(ab, { type: 'array' });
 
+    const sheetNames = Object.keys(wb.Sheets || {});
+    log('Detected sheets: ' + sheetNames.join(', '));
+
+    const names = (wb.Workbook && Array.isArray(wb.Workbook.Names)) ? wb.Workbook.Names : [];
+    if (names.length) {
+      names.forEach(n => log(`Defined name: ${n.Name} -> ${n.Ref}`));
+    } else {
+      log('No defined names');
+    }
+
+    let tableSheetName;
+    let tableRange;
+    const infoName = names.find(n => n.Name === 'INFOTable');
+    if (infoName) {
+      log(`Found named range INFOTable: ${infoName.Ref}`);
+      const idx = infoName.Ref.indexOf('!');
+      if (idx !== -1) {
+        const rawSheet = infoName.Ref.slice(0, idx);
+        tableRange = infoName.Ref.slice(idx + 1);
+        tableSheetName = rawSheet.replace(/^'/, '').replace(/'$/, '');
+        log(`INFOTable sheet: ${tableSheetName}`);
+        log(`INFOTable range: ${tableRange}`);
+        const ws = wb.Sheets[tableSheetName];
+        if (ws) {
+          const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range: tableRange });
+          renderTable(rows);
+          const colCount = rows.reduce((m, r) => Math.max(m, r.length), 0);
+          log(`Rendered ${rows.length} rows and ${colCount} columns`);
+        } else {
+          setStatus(`Sheet ${tableSheetName} not found`);
+          log(`Sheet ${tableSheetName} not found`);
+        }
+      }
+    } else {
+      log("Named range 'INFOTable' not found");
+      setStatus("Named range 'INFOTable' not found");
+      document.getElementById('table').textContent = '';
+    }
+
+    const c1SheetName = tableSheetName || sheetNames[0];
+    if (c1SheetName) {
+      log(`Reading cell C1 from sheet ${c1SheetName}`);
+      const ws = wb.Sheets[c1SheetName];
+      if (ws) {
+        const cell = ws['C1'];
+        if (cell) {
+          const val = cell.w || cell.v;
+          document.getElementById('cellC1').textContent = 'C1: ' + val;
+          log(`C1 value: ${val}`);
+        } else {
+          document.getElementById('cellC1').textContent = 'C1: (not found)';
+          log('C1 not found');
+        }
+      } else {
+        document.getElementById('cellC1').textContent = 'C1: (sheet not found)';
+        log(`Sheet for C1 not found: ${c1SheetName}`);
+      }
+    } else {
+      document.getElementById('cellC1').textContent = 'C1: (no sheets)';
+      log('No sheets in workbook');
+    }
+  } catch (err) {
+    log('Error parsing workbook: ' + err.message);
+    if (err.stack) log(err.stack);
+    setStatus('Error: ' + err.message);
+  }
+}
+
+async function loadFromURL() {
+  clearLog();
+  setStatus('');
+  document.getElementById('cellC1').textContent = '';
+  document.getElementById('table').innerHTML = '';
+
+  const url = document.getElementById('urlInput').value.trim();
+  if (!url) {
+    setStatus('Please enter a URL');
+    log('No URL provided');
+    return;
+  }
+  try {
+    const resolved = new URL(url, window.location.href).href;
+    log('Resolved URL: ' + resolved);
+    const resp = await fetch(resolved);
+    log(`Fetch status: ${resp.status} ${resp.statusText}`);
+    log('content-type: ' + resp.headers.get('content-type'));
+    log('content-length: ' + resp.headers.get('content-length'));
+    if (!resp.ok) {
+      const errMsg = `HTTP error ${resp.status} ${resp.statusText}`;
+      log(errMsg);
+      setStatus(errMsg);
+      return;
+    }
+    const ab = await resp.arrayBuffer();
+    log('ArrayBuffer length: ' + ab.byteLength);
+    handleWorkbook(ab);
+  } catch (err) {
+    log('Error fetching URL: ' + err.message);
+    if (err.stack) log(err.stack);
+    setStatus('Error: ' + err.message);
+  }
+}
+
+function loadFromFile() {
+  clearLog();
+  setStatus('');
+  document.getElementById('cellC1').textContent = '';
+  document.getElementById('table').innerHTML = '';
+
+  const input = document.getElementById('fileInput');
+  const file = input.files && input.files[0];
+  if (!file) {
+    setStatus('Please select a file');
+    log('No file selected');
+    return;
+  }
+  log(`Selected file: ${file.name} (${file.size} bytes)`);
+  const reader = new FileReader();
+  reader.onload = function (e) {
+    const ab = e.target.result;
+    log('File read: ' + ab.byteLength + ' bytes');
+    handleWorkbook(ab);
+  };
+  reader.onerror = function (e) {
+    const err = e.target.error;
+    log('FileReader error: ' + (err && err.message));
+    if (err && err.stack) log(err.stack);
+    setStatus('Error reading file');
+  };
+  reader.readAsArrayBuffer(file);
+}
+
+document.getElementById('loadUrlBtn').addEventListener('click', loadFromURL);
+document.getElementById('loadFileBtn').addEventListener('click', loadFromFile);


### PR DESCRIPTION
## Summary
- add URL and file-based loading options for Excel diagnostics
- render INFOTable and show cell C1 with detailed logging
- style debug area for readability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af133d64c88324b6c0df3371da32ef