### PR TITLE
Add diagnostic Excel loader with robust logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,15 +6,39 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>INFOTable contents</h1>
+  <h1>INFOTable Viewer</h1>
 
-  <label for="file">Excel file path:</label>
-  <input id="file" type="text" placeholder="path/to/workbook.xlsx" />
-  <button id="loadBtn">Load</button>
+  <div>
+    <label for="urlInput">Excel URL:</label>
+    <input id="urlInput" type="text" placeholder="http://localhost:5000/TestData.xlsm" />
+    <button id="loadUrlBtn">Load via URL</button>
+  </div>
+
+  <div>
+    <label for="fileInput">Local file:</label>
+    <input id="fileInput" type="file" accept=".xlsx,.xlsm,.xlsb,.xls" />
+    <button id="loadFileBtn">Load local file</button>
+  </div>
+
+  <div id="status"></div>
+
+  <div>
+    <label for="tableList">Tables / Ranges:</label>
+    <select id="tableList"></select>
+    <button id="renderBtn">Render selected table</button>
+  </div>
+
+  <h2>C1 Cell</h2>
+  <div id="cellC1"></div>
+
+  <h2>Table Preview</h2>
   <div id="table"></div>
+
   <h2>Debug log</h2>
   <pre id="debug"></pre>
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/exceljs@4.3.0/dist/exceljs.min.js"></script>
   <script src="viewer.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -10,3 +10,11 @@ td, th {
   border: 1px solid #ccc;
   padding: 4px 8px;
 }
+
+#debug {
+  border: 1px solid #ccc;
+  padding: 4px;
+  height: 200px;
+  overflow: auto;
+  background: #f9f9f9;
+}

--- a/viewer.js
+++ b/viewer.js
@@ -1,42 +1,25 @@
-async function loadTable(file) {
-  const debug = msg => {
-    console.log(msg);
-    const el = document.getElementById('debug');
-    if (el) el.textContent += msg + '\n';
-  };
-  try {
-    debug('Fetching ' + file + '...');
-    const resp = await fetch(file);
-    debug(`Fetch status: ${resp.status}`);
-    if (!resp.ok) throw new Error('unable to fetch ' + file);
+/* global XLSX, ExcelJS */
 
-    const buf = await resp.arrayBuffer();
-    debug('Workbook loaded, parsing...');
-    const wb = XLSX.read(buf, { type: 'array' });
-    debug('Workbook sheets: ' + wb.SheetNames.join(', '));
-
-    const name = wb.Workbook && wb.Workbook.Names
-      ? wb.Workbook.Names.find(n => n.Name === 'INFOTable')
-      : null;
-    if (!name) throw new Error('table "INFOTable" not found');
-    debug('Found table range: ' + name.Ref);
-
-    const [sheetNameRaw, range] = name.Ref.split('!');
-    const sheetName = sheetNameRaw.replace(/^'/, '').replace(/'$/, '');
-    debug(`Using sheet "${sheetName}" range "${range}"`);
-    const ws = wb.Sheets[sheetName];
-    if (!ws) throw new Error(`sheet "${sheetName}" not found`);
-
-    const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range });
-    debug('Rendering ' + rows.length + ' rows');
-    render(rows);
-  } catch (err) {
-    debug('Error: ' + err.message);
-    document.getElementById('table').textContent = 'Error: ' + err.message;
-  }
+function log(msg) {
+  console.log(msg);
+  const el = document.getElementById('debug');
+  if (el) el.textContent += msg + '\n';
 }
 
-function render(rows) {
+function clearLog() {
+  const el = document.getElementById('debug');
+  if (el) el.textContent = '';
+}
+
+function setStatus(msg) {
+  const el = document.getElementById('status');
+  if (el) el.textContent = msg || '';
+}
+
+let sheetjsWb; // SheetJS workbook
+let tableEntries = []; // options for dropdown
+
+function renderTable(rows) {
   const container = document.getElementById('table');
   container.innerHTML = '';
   const table = document.createElement('table');
@@ -52,10 +35,247 @@ function render(rows) {
   container.appendChild(table);
 }
 
-document.getElementById('loadBtn').addEventListener('click', () => {
-  const file = document.getElementById('file').value.trim();
-  document.getElementById('table').textContent = 'Loading...';
-  document.getElementById('debug').textContent = '';
-  loadTable(file);
-});
+function populateDropdown() {
+  const sel = document.getElementById('tableList');
+  sel.innerHTML = '';
+  tableEntries.forEach((t, i) => {
+    const opt = document.createElement('option');
+    if (t.type === 'table') {
+      opt.textContent = `${t.sheet}: ${t.name} [${t.ref}]`;
+    } else if (t.type === 'name') {
+      opt.textContent = `${t.sheet}: ${t.name} [${t.ref}]`;
+    } else {
+      opt.textContent = `${t.sheet}: (preview first 50x50)`;
+    }
+    opt.value = String(i);
+    sel.appendChild(opt);
+  });
+}
+
+function showC1(sheetName) {
+  const cellDiv = document.getElementById('cellC1');
+  if (!sheetjsWb) {
+    cellDiv.textContent = 'C1: (no workbook)';
+    return;
+  }
+  const sheetNames = Object.keys(sheetjsWb.Sheets || {});
+  let target = sheetName;
+  if (!target) {
+    target = sheetNames.includes('INFO') ? 'INFO' : sheetNames[0];
+  }
+  if (!target) {
+    cellDiv.textContent = 'C1: (no sheets)';
+    log('No sheets in workbook');
+    return;
+  }
+  log(`Reading cell C1 from sheet ${target}`);
+  const ws = sheetjsWb.Sheets[target];
+  if (!ws) {
+    cellDiv.textContent = 'C1: (sheet not found)';
+    log(`Sheet for C1 not found: ${target}`);
+    return;
+  }
+  const cell = ws['C1'];
+  if (cell) {
+    const val = cell.w || cell.v;
+    cellDiv.textContent = 'C1: ' + val;
+    log(`C1 value: ${val}`);
+  } else {
+    cellDiv.textContent = 'C1: (not found)';
+    log('C1 not found');
+  }
+}
+
+async function handleWorkbook(ab) {
+  try {
+    log('Parsing workbook with SheetJS...');
+    const wb = XLSX.read(ab, { type: 'array' });
+    sheetjsWb = wb;
+
+    const sheetNames = Object.keys(wb.Sheets || {});
+    log('Detected sheets: ' + sheetNames.join(', '));
+
+    const names = (wb.Workbook && Array.isArray(wb.Workbook.Names)) ? wb.Workbook.Names : [];
+    if (names.length) {
+      names.forEach(n => log(`Defined name: ${n.Name} -> ${n.Ref}`));
+    } else {
+      log('No defined names');
+    }
+    if (!names.find(n => n.Name === 'INFOTable')) {
+      log("Named range 'INFOTable' not found");
+    }
+
+    tableEntries = [];
+
+    if (typeof ExcelJS !== 'undefined') {
+      log('Loading workbook with ExcelJS for table discovery...');
+      const ex = new ExcelJS.Workbook();
+      await ex.xlsx.load(ab);
+      ex.eachSheet(ws => {
+        const wsTables = ws.tables || {};
+        Object.keys(wsTables).forEach(tname => {
+          const t = ws.getTable ? ws.getTable(tname) : wsTables[tname];
+          const addr = t && t.table ? t.table.ref : (t && t.ref ? t.ref : '');
+          tableEntries.push({ type: 'table', sheet: ws.name, name: tname, ref: addr });
+          log(`Table: ${tname} on sheet ${ws.name} range ${addr}`);
+        });
+      });
+    } else {
+      log('ExcelJS not available');
+    }
+
+    if (!tableEntries.length) {
+      log('No Excel Tables found');
+      if (names.length) {
+        names.forEach(n => {
+          const idx = n.Ref.indexOf('!');
+          let sheet = sheetNames[0];
+          let ref = n.Ref;
+          if (idx !== -1) {
+            sheet = n.Ref.slice(0, idx).replace(/^'/, '').replace(/'$/, '');
+            ref = n.Ref.slice(idx + 1);
+          }
+          tableEntries.push({ type: 'name', sheet, name: n.Name, ref });
+        });
+      } else {
+        sheetNames.forEach(sn => {
+          tableEntries.push({ type: 'sheet', sheet: sn, name: sn });
+        });
+      }
+    }
+
+    populateDropdown();
+    const firstSheet = tableEntries[0] ? tableEntries[0].sheet : (sheetNames.includes('INFO') ? 'INFO' : sheetNames[0]);
+    showC1(firstSheet);
+  } catch (err) {
+    log('Error parsing workbook: ' + err.message);
+    if (err.stack) log(err.stack);
+    setStatus('Error: ' + err.message);
+  }
+}
+
+async function loadFromURL() {
+  clearLog();
+  setStatus('');
+  document.getElementById('cellC1').textContent = '';
+  document.getElementById('table').innerHTML = '';
+
+  const url = document.getElementById('urlInput').value.trim();
+  if (!url) {
+    setStatus('Please enter a URL');
+    log('No URL provided');
+    return;
+  }
+  try {
+    const resolved = new URL(url, window.location.href).href;
+    log('Resolved URL: ' + resolved);
+    const resp = await fetch(resolved);
+    log(`Fetch status: ${resp.status} ${resp.statusText}`);
+    log('content-type: ' + resp.headers.get('content-type'));
+    log('content-length: ' + resp.headers.get('content-length'));
+    if (!resp.ok) {
+      const errMsg = `HTTP error ${resp.status} ${resp.statusText}`;
+      log(errMsg);
+      setStatus(errMsg);
+      return;
+    }
+    const ab = await resp.arrayBuffer();
+    log('ArrayBuffer length: ' + ab.byteLength);
+    await handleWorkbook(ab);
+  } catch (err) {
+    log('Error fetching URL: ' + err.message);
+    if (err.stack) log(err.stack);
+    setStatus('Error: ' + err.message);
+  }
+}
+
+function loadFromFile() {
+  clearLog();
+  setStatus('');
+  document.getElementById('cellC1').textContent = '';
+  document.getElementById('table').innerHTML = '';
+
+  const input = document.getElementById('fileInput');
+  const file = input.files && input.files[0];
+  if (!file) {
+    setStatus('Please select a file');
+    log('No file selected');
+    return;
+  }
+  log(`Selected file: ${file.name} (${file.size} bytes)`);
+  const reader = new FileReader();
+  reader.onload = function (e) {
+    const ab = e.target.result;
+    log('File read: ' + ab.byteLength + ' bytes');
+    handleWorkbook(ab);
+  };
+  reader.onerror = function (e) {
+    const err = e.target.error;
+    log('FileReader error: ' + (err && err.message));
+    if (err && err.stack) log(err.stack);
+    setStatus('Error reading file');
+  };
+  reader.readAsArrayBuffer(file);
+}
+
+  function renderSelected() {
+    setStatus('');
+    const sel = document.getElementById('tableList');
+    const idx = sel.selectedIndex;
+    const info = tableEntries[idx];
+    if (!info) {
+      log('No selection to render');
+      setStatus('Please select a table or range');
+      return;
+    }
+    if (!sheetjsWb) {
+      log('No workbook loaded');
+      setStatus('No workbook loaded');
+      return;
+    }
+    if (info.type === 'table' || info.type === 'name') {
+      log(`Rendering ${info.type === 'table' ? 'table' : 'named range'} ${info.name} on sheet ${info.sheet} range ${info.ref}`);
+      const ws = sheetjsWb.Sheets[info.sheet];
+      if (ws) {
+        const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range: info.ref });
+        renderTable(rows);
+        const colCount = rows.reduce((m, r) => Math.max(m, r.length), 0);
+        log(`Rendered ${rows.length} rows and ${colCount} columns`);
+      } else {
+        log(`Sheet ${info.sheet} not found`);
+        setStatus(`Sheet ${info.sheet} not found`);
+      }
+    } else if (info.type === 'sheet') {
+      log(`Rendering sheet preview for ${info.sheet}`);
+      const ws = sheetjsWb.Sheets[info.sheet];
+      if (ws) {
+        const used = XLSX.utils.decode_range(ws['!ref'] || 'A1');
+        const range = {
+          s: { r: used.s.r, c: used.s.c },
+          e: { r: Math.min(used.e.r, used.s.r + 49), c: Math.min(used.e.c, used.s.c + 49) }
+        };
+        const rangeStr = XLSX.utils.encode_range(range);
+        const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range: rangeStr });
+        renderTable(rows);
+        const colCount = rows.reduce((m, r) => Math.max(m, r.length), 0);
+        log(`Rendered preview ${rows.length} rows and ${colCount} columns from ${info.sheet} (${rangeStr})`);
+      } else {
+        log(`Sheet ${info.sheet} not found`);
+        setStatus(`Sheet ${info.sheet} not found`);
+      }
+    }
+    showC1(info.sheet);
+  }
+
+document.getElementById('loadUrlBtn').addEventListener('click', loadFromURL);
+document.getElementById('loadFileBtn').addEventListener('click', loadFromFile);
+document.getElementById('renderBtn').addEventListener('click', renderSelected);
+
+/*
+ * Usage:
+ * Option A: open index.html and use "Load local file" (no CORS issues).
+ * Option B: serve the Excel file over HTTP and use "Load via URL". Local
+ *           paths like C:\... cannot be fetched by the browser; use
+ *           http://localhost/... instead.
+ */
 


### PR DESCRIPTION
## Summary
- add URL and file-based loading options for Excel diagnostics
- render INFOTable and show cell C1 with detailed logging
- style debug area for readability
- discover Excel tables via ExcelJS and allow rendering selected tables or ranges
- clean up loader functions after resolving merge conflicts
- clarify usage notes for URL loading
- align top-level event listeners and usage instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af133d64c88324b6c0df3371da32ef