### PR TITLE
feat: enable editing and saving Excel table previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,13 @@
     <button id="loadFileBtn">Load local file</button>
   </div>
 
+  <div class="toolbar">
+    <button id="openFsBtn">Open for edit (local, FS Access)</button>
+    <button id="saveBtn" disabled>Save</button>
+    <button id="downloadBtn">Download copy</button>
+    <span id="fsMessage"></span>
+  </div>
+
   <div id="status"></div>
 
   <div>

--- a/style.css
+++ b/style.css
@@ -23,7 +23,21 @@ table {
 }
 td, th {
   border: 1px solid #ccc;
-  padding: 4px 8px;
+  padding: 0;
+}
+
+input.cell {
+  width: 100%;
+  box-sizing: border-box;
+  border: none;
+  padding: 4px;
+}
+
+.toolbar {
+  margin: 10px 0;
+}
+.toolbar button {
+  margin-right: 5px;
 }
 
 #debug {


### PR DESCRIPTION
## Summary
- Render selected Excel ranges as editable grids and track edits
- Support opening files via File System Access API and saving changes
- Allow downloading edited workbook copies when saving is unavailable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05743b6e883248601b5667d40e807