### PR TITLE
feat: add format-preserving save with diagnostics

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <header class="app-header">Audentes LabOps+</header>
+  <header class="app-header">Audentes LabOps+ iuvat</header>
   <div class="container">
 
   <div>
@@ -23,8 +23,9 @@
 
   <div class="toolbar">
     <button id="openFsBtn">Open for edit (local, FS Access)</button>
-    <button id="saveBtn" disabled>Save</button>
-    <button id="downloadBtn">Download copy</button>
+    <button id="saveFmtBtn" disabled>Save (preserve)</button>
+    <button id="downloadFmtBtn">Download copy (preserve)</button>
+    <button id="downloadBtn">Download copy (data-only)</button>
     <span id="fsMessage"></span>
   </div>
 
@@ -50,6 +51,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/exceljs@4.3.0/dist/exceljs.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
   <script src="viewer.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -40,7 +40,7 @@ input.cell {
 
 #tableContainer {
   overflow-x: auto;
-
+  max-width: 100%;
 }
 
 .toolbar {

--- a/viewer.js
+++ b/viewer.js
@@ -1,10 +1,15 @@
-/* global XLSX, ExcelJS */
+/* global XLSX, ExcelJS, JSZip */
 
 
 function log(msg) {
   console.log(msg);
   const el = document.getElementById('debug');
   if (el) el.textContent += msg + '\n';
+}
+
+const DEBUG_MODE = true;
+function logKV(label, obj) {
+  log(label + ': ' + (typeof obj === 'string' ? obj : JSON.stringify(obj)));
 }
 
 function clearLog() {
@@ -24,11 +29,12 @@ let currentSelection = null; // metadata for selected range
 let currentFileHandle = null; // FileSystemFileHandle when opened via FS access
 let currentFileName = '';
 let currentBookType = 'xlsx';
-const fsSupported = ('showOpenFilePicker' in window);
+let originalFileAB = null; // original file ArrayBuffer for patching
+const fsSupported = ('showOpenFilePicker' in window) && (location.protocol === 'https:' || location.hostname === 'localhost');
 
 function updateSaveButton() {
-  const btn = document.getElementById('saveBtn');
-  if (btn) btn.disabled = !currentFileHandle;
+  const fmtBtn = document.getElementById('saveFmtBtn');
+  if (fmtBtn) fmtBtn.disabled = !currentFileHandle;
 }
 
 function renderTable(rows) {
@@ -196,7 +202,8 @@ async function loadFromURL() {
   document.getElementById('cellC1').textContent = '';
   document.getElementById('table').innerHTML = '';
 
-  const url = document.getElementById('urlInput').value.trim();
+  const urlInput = document.getElementById('urlInput').value;
+  const url = typeof urlInput === 'string' ? urlInput.trim() : '';
   if (!url) {
     setStatus('Please enter a URL');
     log('No URL provided');
@@ -220,6 +227,7 @@ async function loadFromURL() {
     currentFileHandle = null;
     currentFileName = resolved.split('/').pop().split('?')[0] || 'workbook.xlsx';
     currentBookType = currentFileName.toLowerCase().endsWith('.xlsm') ? 'xlsm' : 'xlsx';
+    originalFileAB = ab.slice(0);
     await handleWorkbook(ab);
     setStatus(`Loaded ${currentFileName}`);
     updateSaveButton();
@@ -252,6 +260,7 @@ async function loadFromFile() {
     currentFileHandle = null;
     currentFileName = file.name;
     currentBookType = file.name.toLowerCase().endsWith('.xlsm') ? 'xlsm' : 'xlsx';
+    originalFileAB = ab.slice(0);
     await handleWorkbook(ab);
     setStatus(`Loaded ${file.name} (use "Open for edit" to enable saving)`);
     updateSaveButton();
@@ -264,6 +273,8 @@ async function loadFromFile() {
   };
   reader.readAsArrayBuffer(file);
 }
+
+let currentFileLastModified = 0;
 
 async function openForEdit() {
   if (!fsSupported) {
@@ -286,8 +297,10 @@ async function openForEdit() {
     const file = await handle.getFile();
     currentFileName = file.name;
     currentBookType = currentFileName.toLowerCase().endsWith('.xlsm') ? 'xlsm' : 'xlsx';
+    currentFileLastModified = file.lastModified;
     const ab = await file.arrayBuffer();
     log(`Opened ${currentFileName} via FS Access (${ab.byteLength} bytes)`);
+    originalFileAB = ab.slice(0);
     await handleWorkbook(ab);
     setStatus(`Loaded ${currentFileName} for editing`);
   } catch (err) {
@@ -298,63 +311,277 @@ async function openForEdit() {
   updateSaveButton();
 }
 
+function safeSample(v) {
+  try {
+    return typeof v === 'string' ? v.slice(0, 50) : JSON.stringify(v).slice(0, 120);
+  } catch (e) {
+    return String(v).slice(0, 120);
+  }
+}
+
+function normalizeForWrite(raw) {
+  if (raw == null || (typeof raw === 'string' && raw.trim() === '')) return { kind: 'blank' };
+  if (typeof raw === 'number') {
+    return isNaN(raw) ? { kind: 'string', v: String(raw) } : { kind: 'number', v: raw };
+  }
+  if (typeof raw === 'boolean') return { kind: 'boolean', v: raw };
+  if (typeof raw === 'string') {
+    const s = raw;
+    const t = s.trim();
+    if (t === '') return { kind: 'blank' };
+    if (isFinite(Number(t))) return { kind: 'number', v: Number(t) };
+    return { kind: 'string', v: s };
+  }
+  if (typeof raw === 'object') {
+    if (raw && typeof raw.v !== 'undefined') return normalizeForWrite(raw.v);
+    const prim = String(raw);
+    const norm = normalizeForWrite(prim);
+    if (norm.kind === 'string' && norm.v === prim) {
+      log(`[normalizeForWrite] treating ${typeof raw} as string ${safeSample(prim)}`);
+    }
+    return norm;
+  }
+  return { kind: 'string', v: String(raw) };
+}
+
 function applyEdits() {
-  if (!sheetjsWb || !currentSelection) return;
+  if (!sheetjsWb || !currentSelection) return [];
   const ws = sheetjsWb.Sheets[currentSelection.sheet];
-  if (!ws) return;
+  if (!ws) return [];
+  const errors = [];
+  const patches = [];
+  let processed = 0;
   for (let r = 0; r < editableData.length; ++r) {
     for (let c = 0; c < editableData[r].length; ++c) {
-      const val = editableData[r][c];
+      const raw = editableData[r][c];
       const addr = XLSX.utils.encode_cell({ r: currentSelection.start.r + r, c: currentSelection.start.c + c });
-      if (val === '') {
-        delete ws[addr];
-      } else if (val.trim() !== '' && isFinite(Number(val))) {
-
-        ws[addr] = { t: 'n', v: Number(val) };
-      } else {
-        ws[addr] = { t: 's', v: val };
+      try {
+        const norm = normalizeForWrite(raw);
+        patches.push({ addr, norm });
+        if (norm.kind === 'blank') {
+          delete ws[addr];
+        } else if (norm.kind === 'number') {
+          ws[addr] = { t: 'n', v: norm.v };
+        } else if (norm.kind === 'boolean') {
+          ws[addr] = { t: 'b', v: norm.v };
+        } else {
+          ws[addr] = { t: 's', v: norm.v };
+        }
+      } catch (e) {
+        errors.push({ r, c, addr, type: typeof raw, sample: safeSample(raw), message: e.message });
       }
+      processed++;
+      if (DEBUG_MODE && processed % 100 === 0) log(`[applyEdits] processed ${processed} cells`);
     }
   }
+  if (errors.length) {
+    log('[applyEdits] cell write errors: ' + JSON.stringify(errors.slice(0, 10)));
+    const err = new Error('applyEdits failed for ' + errors.length + ' cells (see debug).');
+    err.cells = errors;
+    throw err;
+  }
+  return patches;
 }
 
-async function saveToOriginal() {
-  if (!currentFileHandle) {
-    setStatus('No editable file handle. Use "Open for edit (local)". Downloading copy...');
-    log('Save: missing FileSystemFileHandle; using download copy');
-    downloadCopy();
-    return;
-  }
+async function patchWorkbook(ab, patches, sheetName) {
+  const NS = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+  const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+  const parser = new DOMParser();
+  const serializer = new XMLSerializer();
+  let step = 'load-zip';
   try {
-    await currentFileHandle.getFile();
-    let perm = await currentFileHandle.queryPermission({ mode: 'readwrite' });
-    log('Save: queryPermission -> ' + perm);
-    if (perm !== 'granted') {
-      perm = await currentFileHandle.requestPermission({ mode: 'readwrite' });
-      log('Save: requestPermission -> ' + perm);
-      if (perm !== 'granted') {
-        setStatus('Write permission denied. Downloading copy.');
-        log('Save: permission denied; using download copy');
-        downloadCopy();
-        return;
-      }
+    const zip = await JSZip.loadAsync(ab);
+    step = 'workbook';
+    const wbDoc = parser.parseFromString(await zip.file('xl/workbook.xml').async('string'), 'application/xml');
+    const sheets = Array.from(wbDoc.getElementsByTagNameNS(NS, 'sheet'));
+    let rId = null;
+    sheets.forEach(s => {
+      if (s.getAttribute('name') === sheetName) rId = s.getAttribute('r:id') || s.getAttributeNS('http://schemas.openxmlformats.org/officeDocument/2006/relationships', 'id');
+    });
+    if (!rId) {
+      const err = new Error('sheet mapping failed');
+      err.step = 'resolve-sheet';
+      throw err;
     }
-    applyEdits();
-    const ab = XLSX.write(sheetjsWb, { bookType: currentBookType, type: 'array', bookVBA: true });
-    const w = await currentFileHandle.createWritable();
-    await w.write(ab);
-    await w.close();
-    log(`Saved via FS Access (${ab.byteLength} bytes)`);
+    step = 'rels';
+    const relsDoc = parser.parseFromString(await zip.file('xl/_rels/workbook.xml.rels').async('string'), 'application/xml');
+    const rels = Array.from(relsDoc.getElementsByTagNameNS(REL_NS, 'Relationship'));
+    let sheetPath = null;
+    rels.forEach(r => {
+      if (r.getAttribute('Id') === rId) sheetPath = 'xl/' + r.getAttribute('Target').replace(/^\//, '');
+    });
+    if (!sheetPath) {
+      const err = new Error('worksheet path not found');
+      err.step = 'resolve-sheet';
+      throw err;
+    }
+    step = 'sheet';
+    const sheetDoc = parser.parseFromString(await zip.file(sheetPath).async('string'), 'application/xml');
+    const sheetRoot = sheetDoc.documentElement;
 
-    setStatus('File saved');
+    const sstPath = 'xl/sharedStrings.xml';
+    const useSST = !!zip.file(sstPath);
+    let sstDoc, sstRoot, shared = [], sstCount = 0, sstUnique = 0;
+    if (useSST) {
+      sstDoc = parser.parseFromString(await zip.file(sstPath).async('string'), 'application/xml');
+      sstRoot = sstDoc.documentElement;
+      const sis = Array.from(sstDoc.getElementsByTagNameNS(NS, 'si'));
+      shared = sis.map(si => si.textContent);
+      sstCount = Number(sstRoot.getAttribute('count')) || shared.length;
+      sstUnique = Number(sstRoot.getAttribute('uniqueCount')) || shared.length;
+    }
+
+    const counts = { string: 0, number: 0, boolean: 0, blank: 0 };
+    let sharedReused = 0, sharedAdded = 0;
+    const xmlSpace = 'http://www.w3.org/XML/1998/namespace';
+
+    patches.forEach(p => {
+      const cell = XLSX.utils.decode_cell(p.addr);
+      const rowStr = String(cell.r + 1);
+      let rowNode = Array.from(sheetRoot.getElementsByTagNameNS(NS, 'row')).find(r => r.getAttribute('r') === rowStr);
+      if (!rowNode) {
+        rowNode = sheetDoc.createElementNS(NS, 'row');
+        rowNode.setAttribute('r', rowStr);
+        sheetRoot.appendChild(rowNode);
+      }
+      let cNode = Array.from(rowNode.getElementsByTagNameNS(NS, 'c')).find(c => c.getAttribute('r') === p.addr);
+      if (!cNode) {
+        cNode = sheetDoc.createElementNS(NS, 'c');
+        cNode.setAttribute('r', p.addr);
+        rowNode.appendChild(cNode);
+      }
+      const vNode = cNode.getElementsByTagNameNS(NS, 'v')[0];
+      if (vNode) cNode.removeChild(vNode);
+      const isNode = cNode.getElementsByTagNameNS(NS, 'is')[0];
+      if (isNode) cNode.removeChild(isNode);
+      const fNode = cNode.getElementsByTagNameNS(NS, 'f')[0];
+      if (fNode) cNode.removeChild(fNode);
+      cNode.removeAttribute('t');
+
+      if (p.norm.kind === 'blank') {
+        counts.blank++;
+      } else if (p.norm.kind === 'number') {
+        counts.number++;
+        const newV = sheetDoc.createElementNS(NS, 'v');
+        newV.textContent = String(p.norm.v);
+        cNode.appendChild(newV);
+      } else if (p.norm.kind === 'boolean') {
+        counts.boolean++;
+        cNode.setAttribute('t', 'b');
+        const newV = sheetDoc.createElementNS(NS, 'v');
+        newV.textContent = p.norm.v ? '1' : '0';
+        cNode.appendChild(newV);
+      } else if (p.norm.kind === 'string') {
+        counts.string++;
+        if (useSST) {
+          cNode.setAttribute('t', 's');
+          let idx = shared.indexOf(p.norm.v);
+          if (idx === -1) {
+            idx = shared.length;
+            shared.push(p.norm.v);
+            const si = sstDoc.createElementNS(NS, 'si');
+            const t = sstDoc.createElementNS(NS, 't');
+            if (/^\s|\s$/.test(p.norm.v)) t.setAttributeNS(xmlSpace, 'xml:space', 'preserve');
+            t.textContent = p.norm.v;
+            si.appendChild(t);
+            sstRoot.appendChild(si);
+            sstUnique++;
+            sharedAdded++;
+          } else {
+            sharedReused++;
+          }
+          sstCount++;
+          const newV = sheetDoc.createElementNS(NS, 'v');
+          newV.textContent = String(idx);
+          cNode.appendChild(newV);
+        } else {
+          cNode.setAttribute('t', 'inlineStr');
+          const is = sheetDoc.createElementNS(NS, 'is');
+          const t = sheetDoc.createElementNS(NS, 't');
+          if (/^\s|\s$/.test(p.norm.v)) t.setAttributeNS(xmlSpace, 'xml:space', 'preserve');
+          t.textContent = p.norm.v;
+          is.appendChild(t);
+          cNode.appendChild(is);
+        }
+      }
+    });
+
+    if (useSST) {
+      sstRoot.setAttribute('count', String(sstCount));
+      sstRoot.setAttribute('uniqueCount', String(sstUnique));
+      zip.file(sstPath, serializer.serializeToString(sstDoc));
+    }
+    zip.file(sheetPath, serializer.serializeToString(sheetDoc));
+    const abOut = await zip.generateAsync({ type: 'arraybuffer' });
+    return { ab: abOut, counts, shared: { reused: sharedReused, added: sharedAdded }, sheetPath, sstPath: useSST ? sstPath : null };
   } catch (err) {
-    log('Save error: ' + err.message);
-    if (err.stack) log(err.stack);
-    setStatus('Error saving; using Download copy. Use "Open for edit (local)" to enable saving.');
-    downloadCopy();
-
+    if (!err.step) err.step = step;
+    throw err;
   }
 }
+
+async function verifyPatch(ab, patches, sheetPath, sstPath) {
+  const NS = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+  const parser = new DOMParser();
+  const zip = await JSZip.loadAsync(ab);
+  const sheetDoc = parser.parseFromString(await zip.file(sheetPath).async('string'), 'application/xml');
+  const sstDoc = sstPath && zip.file(sstPath) ? parser.parseFromString(await zip.file(sstPath).async('string'), 'application/xml') : null;
+  const serializer = new XMLSerializer();
+  const probes = [patches[0], patches[Math.floor(patches.length / 2)], patches[patches.length - 1]].filter(Boolean);
+  for (const p of probes) {
+    const cell = XLSX.utils.decode_cell(p.addr);
+    const rowNode = Array.from(sheetDoc.getElementsByTagNameNS(NS, 'row')).find(r => r.getAttribute('r') === String(cell.r + 1));
+    const cNode = rowNode && Array.from(rowNode.getElementsByTagNameNS(NS, 'c')).find(c => c.getAttribute('r') === p.addr);
+    if (!cNode) {
+      logKV('[verify-failed]', { addr: p.addr, reason: 'missing cell' });
+      return false;
+    }
+    if (p.norm.kind === 'blank') {
+      if (cNode.getElementsByTagNameNS(NS, 'v')[0] || cNode.getElementsByTagNameNS(NS, 'is')[0]) {
+        logKV('[verify-failed]', { addr: p.addr, expected: 'blank', snippet: serializer.serializeToString(cNode) });
+        return false;
+      }
+    } else if (p.norm.kind === 'number') {
+      const vNode = cNode.getElementsByTagNameNS(NS, 'v')[0];
+      if (!vNode || vNode.textContent !== String(p.norm.v)) {
+        logKV('[verify-failed]', { addr: p.addr, expected: String(p.norm.v), snippet: serializer.serializeToString(cNode) });
+        return false;
+      }
+    } else if (p.norm.kind === 'boolean') {
+      const vNode = cNode.getElementsByTagNameNS(NS, 'v')[0];
+      const expected = p.norm.v ? '1' : '0';
+      if (!vNode || vNode.textContent !== expected) {
+        logKV('[verify-failed]', { addr: p.addr, expected, snippet: serializer.serializeToString(cNode) });
+        return false;
+      }
+    } else if (p.norm.kind === 'string') {
+      if (sstDoc) {
+        const vNode = cNode.getElementsByTagNameNS(NS, 'v')[0];
+        if (!vNode) {
+          logKV('[verify-failed]', { addr: p.addr, expected: p.norm.v });
+          return false;
+        }
+        const idx = Number(vNode.textContent);
+        const sis = sstDoc.getElementsByTagNameNS(NS, 'si');
+        const text = sis[idx] && sis[idx].textContent;
+        if (text !== p.norm.v) {
+          logKV('[verify-failed]', { addr: p.addr, expected: p.norm.v, actual: text });
+          return false;
+        }
+      } else {
+        const isNode = cNode.getElementsByTagNameNS(NS, 'is')[0];
+        const tNode = isNode && isNode.getElementsByTagNameNS(NS, 't')[0];
+        const text = tNode && tNode.textContent;
+        if (text !== p.norm.v) {
+          logKV('[verify-failed]', { addr: p.addr, expected: p.norm.v, actual: text });
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
 
 function downloadCopy() {
   if (!sheetjsWb) {
@@ -362,20 +589,199 @@ function downloadCopy() {
     log('Download aborted: no workbook');
     return;
   }
+  const selIdx = document.getElementById('tableList').selectedIndex;
+  const info = tableEntries[selIdx] || {};
+  logKV('[download] selection', {
+    table: info.name || '',
+    a1: info.ref || info.range || (currentSelection && currentSelection.range),
+    sheet: currentSelection && currentSelection.sheet,
+    start: currentSelection && currentSelection.start,
+    end: currentSelection && currentSelection.end,
+    rows: editableData.length,
+    cols: Math.max(...editableData.map(r => r.length))
+  });
+  let step = 'start';
   try {
-    applyEdits();
-    const ab = XLSX.write(sheetjsWb, { bookType: currentBookType, type: 'array', bookVBA: true });
+    step = 'applyEdits';
+    const patches = applyEdits();
+    step = 'build-binary';
+    const bookType = currentBookType === 'xlsm' ? 'xlsm' : 'xlsx';
+    const ab = XLSX.write(sheetjsWb, { type: 'array', bookType, bookVBA: currentBookType === 'xlsm' });
+    originalFileAB = ab;
+    step = 'download';
     const base = currentFileName ? currentFileName.replace(/\.[^.]+$/, '') : 'workbook';
     const ext = currentBookType === 'xlsm' ? '.xlsm' : '.xlsx';
     const name = `${base}_edited${ext}`;
-    XLSX.writeFile(sheetjsWb, name, { bookType: currentBookType, bookVBA: true });
+    XLSX.writeFile(sheetjsWb, name, { bookType, bookVBA: currentBookType === 'xlsm' });
     log(`Download copy initiated (${ab.byteLength} bytes)`);
 
     setStatus('Download started');
   } catch (err) {
     log('Download error: ' + err.message);
+    logKV('[download] error', { action: 'download', step, message: err.message });
+    logKV('[download] selection', {
+      table: info.name || '',
+      a1: info.ref || info.range || (currentSelection && currentSelection.range),
+      sheet: currentSelection && currentSelection.sheet,
+      start: currentSelection && currentSelection.start,
+      end: currentSelection && currentSelection.end
+    });
+    if (err.cells) logKV('[download] cells', err.cells.slice(0, 10));
     if (err.stack) log(err.stack);
     setStatus('Error downloading file');
+  }
+}
+
+async function saveToOriginalFmt() {
+  if (!currentFileHandle) {
+    setStatus('No editable file handle. Use "Open for edit (local)" first.');
+    log('Save (preserve) aborted: no handle');
+    return;
+  }
+  const selIdx = document.getElementById('tableList').selectedIndex;
+  const info = tableEntries[selIdx] || {};
+  logKV('[save-preserve] selection', {
+    table: info.name || '',
+    a1: info.ref || info.range || (currentSelection && currentSelection.range),
+    sheet: currentSelection && currentSelection.sheet,
+    start: currentSelection && currentSelection.start,
+    end: currentSelection && currentSelection.end,
+    rows: editableData.length,
+    cols: Math.max(...editableData.map(r => r.length))
+  });
+  let step = 'start';
+  try {
+    step = 'getFile';
+    const freshFile = await currentFileHandle.getFile();
+    log('Save(preserve): lastModified -> ' + freshFile.lastModified);
+    if (currentFileLastModified && freshFile.lastModified !== currentFileLastModified) {
+      if (!confirm('File changed on disk. Overwrite?')) {
+        const err = new Error('external modification');
+        err.step = 'external-change';
+        throw err;
+      }
+    }
+    const origAb = await freshFile.arrayBuffer();
+    step = 'permission';
+    let perm = await currentFileHandle.queryPermission({ mode: 'readwrite' });
+    log('Save(preserve): queryPermission -> ' + perm);
+    if (perm !== 'granted') {
+      perm = await currentFileHandle.requestPermission({ mode: 'readwrite' });
+      log('Save(preserve): requestPermission -> ' + perm);
+      if (perm !== 'granted') {
+        const err = new Error('permission denied');
+        err.step = 'permission';
+        throw err;
+      }
+    }
+    step = 'applyEdits';
+    const patches = applyEdits();
+    step = 'build';
+    let patchedInfo;
+    try {
+      patchedInfo = await patchWorkbook(origAb, patches, currentSelection.sheet);
+    } catch (e) {
+      e.step = e.step || 'build';
+      throw e;
+    }
+    step = 'verify';
+    const ok = await verifyPatch(patchedInfo.ab, patches, patchedInfo.sheetPath, patchedInfo.sstPath);
+    if (!ok) {
+      const err = new Error('verification failed');
+      err.step = 'verify';
+      throw err;
+    }
+    step = 'write';
+    const w = await currentFileHandle.createWritable();
+    await w.truncate(0);
+    await w.write(patchedInfo.ab);
+    await w.close();
+    const after = await currentFileHandle.getFile();
+    currentFileLastModified = after.lastModified;
+    originalFileAB = patchedInfo.ab;
+    logKV('[save-preserve] counts', {
+      strings: patchedInfo.counts.string,
+      numbers: patchedInfo.counts.number,
+      booleans: patchedInfo.counts.boolean,
+      blanks: patchedInfo.counts.blank,
+      sharedReused: patchedInfo.shared.reused,
+      sharedAdded: patchedInfo.shared.added
+    });
+    log(`Saved (preserve formatting) (${patchedInfo.ab.byteLength} bytes)`);
+    setStatus('File saved');
+  } catch (err) {
+    log('Save (preserve) error: ' + err.message);
+    logKV('[save-preserve] error', { action: 'save-preserve', step: err.step || step, message: err.message, name: err.name, stack: err.stack });
+    if (err.cells) logKV('[save-preserve] cells', err.cells.slice(0, 10));
+    setStatus('Error saving file');
+  }
+}
+
+async function downloadCopyFmt() {
+  if (!originalFileAB) {
+    setStatus('No workbook loaded');
+    log('Download (preserve) aborted: no workbook');
+    return;
+  }
+  const selIdx = document.getElementById('tableList').selectedIndex;
+  const info = tableEntries[selIdx] || {};
+  logKV('[download-preserve] selection', {
+    table: info.name || '',
+    a1: info.ref || info.range || (currentSelection && currentSelection.range),
+    sheet: currentSelection && currentSelection.sheet,
+    start: currentSelection && currentSelection.start,
+    end: currentSelection && currentSelection.end,
+    rows: editableData.length,
+    cols: Math.max(...editableData.map(r => r.length))
+  });
+  let step = 'start';
+  try {
+    step = 'applyEdits';
+    const patches = applyEdits();
+    step = 'build';
+    let patchedInfo;
+    try {
+      patchedInfo = await patchWorkbook(originalFileAB, patches, currentSelection.sheet);
+    } catch (e) {
+      e.step = e.step || 'build';
+      throw e;
+    }
+    step = 'verify';
+    const ok = await verifyPatch(patchedInfo.ab, patches, patchedInfo.sheetPath, patchedInfo.sstPath);
+    if (!ok) {
+      const err = new Error('verification failed');
+      err.step = 'verify';
+      throw err;
+    }
+    step = 'download';
+    const base = currentFileName ? currentFileName.replace(/\.[^.]+$/, '') : 'workbook';
+    const ext = currentBookType === 'xlsm' ? '.xlsm' : '.xlsx';
+    const name = `${base}_edited${ext}`;
+    const blob = new Blob([patchedInfo.ab], { type: 'application/octet-stream' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = name;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    originalFileAB = patchedInfo.ab;
+    logKV('[download-preserve] counts', {
+      strings: patchedInfo.counts.string,
+      numbers: patchedInfo.counts.number,
+      booleans: patchedInfo.counts.boolean,
+      blanks: patchedInfo.counts.blank,
+      sharedReused: patchedInfo.shared.reused,
+      sharedAdded: patchedInfo.shared.added
+    });
+    log(`Download (preserve) initiated (${patchedInfo.ab.byteLength} bytes)`);
+    setStatus('Download started');
+  } catch (err) {
+    log('Download (preserve) error: ' + err.message);
+    logKV('[download-preserve] error', { action: 'download-preserve', step: err.step || step, message: err.message, name: err.name, stack: err.stack });
+    if (err.cells) logKV('[download-preserve] cells', err.cells.slice(0, 10));
+    setStatus('Error building download');
   }
 }
 
@@ -402,7 +808,7 @@ function renderSelected() {
       if (range) {
         const decoded = XLSX.utils.decode_range(range);
         const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range, defval: '' });
-        currentSelection = { sheet: info.sheet, range, start: decoded.s };
+        currentSelection = { sheet: info.sheet, range, start: decoded.s, end: decoded.e };
         renderTable(rows);
         const colCount = rows.reduce((m, r) => Math.max(m, r.length), 0);
         log(`Rendered ${rows.length} rows and ${colCount} columns`);
@@ -420,7 +826,7 @@ function renderSelected() {
     if (ws) {
       const decoded = XLSX.utils.decode_range(info.ref);
       const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range: info.ref, defval: '' });
-      currentSelection = { sheet: info.sheet, range: info.ref, start: decoded.s };
+      currentSelection = { sheet: info.sheet, range: info.ref, start: decoded.s, end: decoded.e };
       renderTable(rows);
       const colCount = rows.reduce((m, r) => Math.max(m, r.length), 0);
       log(`Rendered ${rows.length} rows and ${colCount} columns`);
@@ -439,7 +845,7 @@ function renderSelected() {
       };
       const rangeStr = XLSX.utils.encode_range(range);
       const rows = XLSX.utils.sheet_to_json(ws, { header: 1, range: rangeStr, defval: '' });
-      currentSelection = { sheet: info.sheet, range: rangeStr, start: range.s };
+      currentSelection = { sheet: info.sheet, range: rangeStr, start: range.s, end: range.e };
       renderTable(rows);
       const colCount = rows.reduce((m, r) => Math.max(m, r.length), 0);
       log(`Rendered preview ${rows.length} rows and ${colCount} columns from ${info.sheet} (${rangeStr})`);
@@ -455,15 +861,18 @@ document.getElementById('loadUrlBtn').addEventListener('click', loadFromURL);
 document.getElementById('loadFileBtn').addEventListener('click', loadFromFile);
 document.getElementById('renderBtn').addEventListener('click', renderSelected);
 document.getElementById('openFsBtn').addEventListener('click', openForEdit);
-document.getElementById('saveBtn').addEventListener('click', saveToOriginal);
+document.getElementById('saveFmtBtn').addEventListener('click', saveToOriginalFmt);
 
 document.getElementById('downloadBtn').addEventListener('click', downloadCopy);
+document.getElementById('downloadFmtBtn').addEventListener('click', downloadCopyFmt);
 
 if (!fsSupported) {
   const msg = document.getElementById('fsMessage');
-  if (msg) msg.textContent = 'FS Access API not supported; use Download copy.';
-  const openBtn = document.getElementById('openFsBtn');
-  if (openBtn) openBtn.disabled = true;
+  if (msg) msg.textContent = 'FS Access API requires HTTPS or localhost. Use Download copy.';
+  ['openFsBtn', 'saveFmtBtn'].forEach(id => {
+    const b = document.getElementById(id);
+    if (b) b.disabled = true;
+  });
 }
 
 updateSaveButton();


### PR DESCRIPTION
## Summary
- ensure toolbar highlights new Save/Download preserve options and keep data-only fallback
- upgrade JSZip patching with namespace-safe cell updates, shared string handling, and verification
- improve FS Access save reliability with refreshed handles, permission checks, and detailed diagnostics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b070ad9fec832485e36f4482d88a46